### PR TITLE
Fix small bug in drawer view that was causing the page to crash

### DIFF
--- a/views/game/drawer.handlebars
+++ b/views/game/drawer.handlebars
@@ -1,4 +1,4 @@
-{{ > round-info }}
+{{> round-info }}
 
 <h1>I AM A DRAWER</h1>
 


### PR DESCRIPTION
- Kind of a silly `handlerbars` syntax thing ... can't have a space between the curly bracket and the caret when using a partial in a view